### PR TITLE
Formalized OpenGL update for painters.

### DIFF
--- a/src/painters.py
+++ b/src/painters.py
@@ -1,8 +1,8 @@
 from PySide2.QtGui import QOpenGLFunctions
+from PySide2.QtCore import Signal, QObject
 
 from commands import Command
 from geometry import Geometry
-from signals import Signals
 
 class Painter(Command):
     def __init__(self):
@@ -10,7 +10,7 @@ class Painter(Command):
         self.glf=0
 
     def updateGL(self):
-        Signals.get().updateGL.emit()
+        pass
 
     def paintGL(self):
         pass
@@ -33,3 +33,11 @@ class Painter(Command):
 
     def addGeometry(self, geometry:Geometry):
         pass
+
+    def requestUpdateGL(self):
+        Signals.get().requestUpdateGL.emit(self)
+
+
+class PainterSignals(QObject):
+    __metaclass__ = Painter
+    requestUpdateGL = Signal(Painter)


### PR DESCRIPTION
From now on, when `Painter` requires any housekeeping work (other than painting itself) it shall to call `self.reauestUpdateGL()` member function.  After that, when GL Context is active, `Painter.updateGL(self)` will automatically  be called.

in brief, workflow should be as follows:
 - place all GL-dependent code into function `updateGL(self)`
 - prepare all the data before that call
 - execute `self.requestUpdateGL()`
 - when OpenGL context is active, object's `updateGL()` will automatically be called.

NOTE: This is a one-shot request. `updateGL` will be called only once, every time `requestUpdateGL` is executed.